### PR TITLE
Go directly to c9users.io rather than via c9.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ This chat example showcases how to use `socket.io` with a static `express` serve
 
     $ node server.js
 
-Once the server is running, open the project in the shape of 'https://projectname-username.c9.io/'. As you enter your name, watch the Users list (on the left) update. Once you press Enter or Send, the message is shared with all connected clients.
+Once the server is running, open the project in the shape of 'https://projectname-username.c9users.io/'. As you enter your name, watch the Users list (on the left) update. Once you press Enter or Send, the message is shared with all connected clients.


### PR DESCRIPTION
projectname-username.c9.io now returns
"All user generated content on Cloud9 has been moved to c9users.io."